### PR TITLE
Modifying lab io regex to allow for no space between lab identifier a…

### DIFF
--- a/infrastructure/container_payload/run.py
+++ b/infrastructure/container_payload/run.py
@@ -27,7 +27,7 @@ CLI_FILE = "cli.txt"
 
 LAB_IO_FILE = "lab_io.txt"
 
-LAB_IO_REGEX = re.compile("(in|out) *(\d+): (.*)")
+LAB_IO_REGEX = re.compile("(in|out) *(\d+): *(.*)")
 
 
 COMMON_ADC = """


### PR DESCRIPTION
…nd argument string.